### PR TITLE
Fix play time accounting and harden the async save pipeline

### DIFF
--- a/src/com/zachduda/puuids/Cooldowns.java
+++ b/src/com/zachduda/puuids/Cooldowns.java
@@ -1,68 +1,104 @@
 package com.zachduda.puuids;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
+/*
+  Cooldowns are held as expiry timestamps rather than as scheduled removal tasks. That keeps
+  them correct when they're read from the async queue threads, and means no scheduler work at
+  all (the Bukkit scheduler this used to call isn't available on Folia anyway).
+ */
 public class Cooldowns {
-    protected static boolean canRunLargeTask = true;
-    static ArrayList<UUID> joined = new ArrayList<>();
-    @SuppressWarnings("SpellCheckingInspection")
-    static ArrayList<UUID> ontime = new ArrayList<>();
+    private static final long JOIN_COOLDOWN_MS = 30_000L;
+    private static final long LARGE_TASK_COOLDOWN_MS = 45_000L;
+    private static final long CONFIRM_MS = 10_000L;
 
+    private static final Map<UUID, Long> joined = new ConcurrentHashMap<>();
     @SuppressWarnings("SpellCheckingInspection")
-    static HashMap<Player, String> confirmall = new HashMap<>();
+    private static final Map<UUID, Long> ontime = new ConcurrentHashMap<>();
+    @SuppressWarnings("SpellCheckingInspection")
+    private static final Map<UUID, String> confirmall = new ConcurrentHashMap<>();
+    private static final Map<UUID, Long> confirmexpiry = new ConcurrentHashMap<>();
+
+    private static volatile long largeTaskReadyAt = 0L;
+
     private static final Main plugin = Main.getPlugin(Main.class);
 
-    static void clearAll(Player p) {
-        joined.clear();
-        ontime.clear();
-        confirmall.remove(p);
-        // Doesn't include queued join updates or plugin lists.
+    private static boolean active(Map<UUID, Long> cooldowns, UUID p) {
+        final Long until = cooldowns.get(p);
+        if (until == null) {
+            return false;
+        }
+        if (until <= System.currentTimeMillis()) {
+            cooldowns.remove(p, until);
+            return false;
+        }
+        return true;
+    }
+
+    /** Forgets one player. Only their own entries, never everybody else's. */
+    static void clearAll(UUID p) {
+        joined.remove(p);
+        ontime.remove(p);
+        clearConfirm(p);
+    }
+
+    static boolean recentlyJoined(UUID p) {
+        return active(joined, p);
     }
 
     static void justJoined(UUID p) {
-        if (joined.contains(p)) {
-            return;
-        }
-
-        joined.add(p);
-
-        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> joined.remove(p), 20 * 30);
+        joined.put(p, System.currentTimeMillis() + JOIN_COOLDOWN_MS);
     }
 
+    @SuppressWarnings("SpellCheckingInspection")
+    static boolean onTimeCooling(UUID p) {
+        return active(ontime, p);
+    }
+
+    @SuppressWarnings("SpellCheckingInspection")
     static void onTime(UUID p) {
-        if (ontime.contains(p)) {
+        if (!plugin.getConfig().getBoolean("Settings.Cooldowns.On-Time.Enabled", true)) {
             return;
         }
 
-        if (!plugin.getConfig().getBoolean("Settings.Cooldowns.Enabled")) {
+        final long seconds = Math.max(0, plugin.getConfig().getInt("Settings.Cooldowns.On-Time.Seconds", 5));
+        if (seconds == 0) {
             return;
         }
 
-        ontime.add(p);
+        ontime.put(p, System.currentTimeMillis() + (seconds * 1000L));
+    }
 
-        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> ontime.remove(p), 20L * plugin.getConfig().getInt("Settings.Cooldowns.On-Time.Seconds"));
+    static boolean canRunLargeTask() {
+        return System.currentTimeMillis() >= largeTaskReadyAt;
     }
 
     static void startLargeTask() {
-        canRunLargeTask = false;
+        largeTaskReadyAt = Long.MAX_VALUE;
     }
 
     static void endLargeTask() {
-        if (canRunLargeTask) {
-            return;
-        }
-
-        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> canRunLargeTask = true, 20 * 45);
+        largeTaskReadyAt = System.currentTimeMillis() + LARGE_TASK_COOLDOWN_MS;
     }
 
-    static void confirm(Player p, String key) {
-        confirmall.put(p, key);
+    /** The pending confirmation key for a player, or null once it has expired. */
+    static String confirmKey(UUID p) {
+        if (!active(confirmexpiry, p)) {
+            confirmall.remove(p);
+            return null;
+        }
+        return confirmall.get(p);
+    }
 
-        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> confirmall.remove(p, key), 20 * 10);
+    static void confirm(UUID p, String key) {
+        confirmall.put(p, key);
+        confirmexpiry.put(p, System.currentTimeMillis() + CONFIRM_MS);
+    }
+
+    static void clearConfirm(UUID p) {
+        confirmall.remove(p);
+        confirmexpiry.remove(p);
     }
 }

--- a/src/com/zachduda/puuids/Main.java
+++ b/src/com/zachduda/puuids/Main.java
@@ -34,6 +34,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Main extends JavaPlugin implements Listener {
 
@@ -41,25 +43,29 @@ public class Main extends JavaPlugin implements Listener {
     @SuppressWarnings("FieldMayBeFinal")
     private static HashMap<Plugin, APIVersion> plugins = new HashMap<>();
 
-    private static boolean allowconnections = false;
-    private static boolean allow_unsafe_reloads = false;
-    public int getTimes = 0;
+    private static volatile boolean allowconnections = false;
+    private static volatile boolean allow_unsafe_reloads = false;
+    public final AtomicInteger getTimes = new AtomicInteger();
     public PUUIDS api;
     public MorePaperLib mpl = new MorePaperLib(this);
-    boolean debug = false;
-    boolean asyncrunning = false;
-    long setTimeMS = 0; // how long in ms for file saving
-    int setTimes = 0;
-    long qTimesMS = 0;
-    int setQRequests = 0;
+    volatile boolean debug = false;
+    volatile boolean asyncrunning = false;
+    volatile long setTimeMS = 0; // how long in ms for file saving
+    final AtomicInteger setTimes = new AtomicInteger();
+    volatile long qTimesMS = 0;
+    volatile int setQRequests = 0;
     private final String version = Bukkit.getBukkitVersion().replace("-SNAPSHOT", "");
-    private boolean sounds;
-    private boolean status;
-    private String statusreason = "0";
-    private boolean updatecheck = true;
+    private volatile boolean sounds;
+    private volatile boolean status;
+    private volatile String statusreason = "0";
+    private volatile boolean updatecheck = true;
     private final boolean isFullySupported = version.contains("1.21") || version.contains("1.20") || version.contains("1.19") || version.contains("1.18") || version.contains("1.17") || version.contains("1.16") || version.contains("1.15") || version.contains("1.14") || version.contains("1.13");
-    private int taskresetid = 0;
-    private int playerupdateid = 0;
+    private ScheduledTask taskresettimer;
+    private ScheduledTask playerupdatetimer;
+    private volatile int playerupdateseconds = 300;
+
+    // Lower-cased username -> UUID, so name lookups don't have to parse every file on disk.
+    private final Map<String, String> nameindex = new ConcurrentHashMap<>();
 
     private Metrics metrics;
 
@@ -71,10 +77,11 @@ public class Main extends JavaPlugin implements Listener {
         }
 
         try {
-            Class.forName("com.google.common.collect.Multimap");
-            Class.forName("com.google.common.collect.ArrayListMultimap");
+            // The queues are plain java.util.concurrent now, so Multimap is no longer required -
+            // checking for it would have disabled the plugin over a class it never touches.
+            Class.forName("com.google.common.io.Files");
         } catch (ClassNotFoundException e) {
-            getLogger().severe("Missing Google's Util Common Multimap. This is normally found in Java 8, but is missing with this version of Java. puuids will now disable...");
+            getLogger().severe("Missing Google's Util Common IO. This is normally shipped with the server, but is missing here. puuids will now disable...");
             Bukkit.getPluginManager().disablePlugin(this);
             return;
         }
@@ -89,13 +96,22 @@ public class Main extends JavaPlugin implements Listener {
         statusreason = "0";
         asyncrunning = true;
 
+        // Read the configuration up front: the cleanup scan below depends on it, and reading it
+        // from another thread while onEnable was still copying defaults meant File-Cleanup and
+        // Debug were both silently off for the whole scan.
+        getConfig().options().copyDefaults(true);
+        saveConfig();
+        updateConfig();
+
         final boolean useclean = getConfig().getBoolean("Settings.File-Cleanup.Enabled");
         final boolean cleaness = getConfig().getBoolean("Settings.File-Cleanup.Clean-Essentials");
 
         mpl.scheduling().asyncScheduler().run(() -> {
             final Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
             final File folder = new File(this.getDataFolder(), File.separator + "Data");
-            if (!folder.exists()) {
+            final File[] cachefiles = folder.exists() ? folder.listFiles() : null;
+            if (cachefiles == null) {
+                asyncrunning = false;
                 return;
             }
 
@@ -103,7 +119,7 @@ public class Main extends JavaPlugin implements Listener {
 
             int maxDays = getConfig().getInt("Settings.File-Cleanup.Max-Days");
 
-            for (File cachefile : Objects.requireNonNull(folder.listFiles())) {
+            for (File cachefile : cachefiles) {
                 String path = cachefile.getPath();
 
                 final File f = new File(path);
@@ -154,10 +170,16 @@ public class Main extends JavaPlugin implements Listener {
                                   https://github.com/EssentialsX/Essentials/blob/3af931740b20507837276f87f9456221653ac43d/Essentials/src/main/java/com/earth2me/essentials/commands/Commandplaytime.java
                                  */
                                 final String uuid = setcache.getString("UUID");
+                                indexName(playername, uuid);
                                 long playtime = 0;
                                 if(isFullySupported) {
                                     try {
-                                        playtime = ((getServer().getOfflinePlayer(UUID.fromString(Objects.requireNonNull(uuid))).getStatistic(EnumUtil.getStatistic("PLAY_ONE_MINUTE", "PLAY_ONE_TICK"))) * 50L);
+                                        // The statistic counts ticks; Time-Played is in seconds.
+                                        // This used to multiply by 50 (giving milliseconds), which
+                                        // overwrote every file with a play time 1000x too large.
+                                        final long ticks = getServer().getOfflinePlayer(UUID.fromString(Objects.requireNonNull(uuid)))
+                                                .getStatistic(EnumUtil.getStatistic("PLAY_ONE_MINUTE", "PLAY_ONE_TICK"));
+                                        playtime = ticks / 20L;
                                     } catch (Exception e) {
                                         if(debug) {
                                             debug("Unable to use getStatistic for player playtime:");
@@ -213,10 +235,10 @@ public class Main extends JavaPlugin implements Listener {
 
         Bukkit.getServer().getPluginManager().registerEvents(this, this);
 
-        getConfig().options().copyDefaults(true);
-        saveConfig();
-
-        updateConfig();
+        // Idempotent; updateConfig() above already started it at the configured rate. The timer
+        // used to be a static final field built during class-load with the hardcoded defaults,
+        // so Advanced.Save-Rate-Ticks never had any effect at all.
+        Timer.startTimer();
 
         mpl.scheduling().globalRegionalScheduler().run(() -> {
 
@@ -282,8 +304,14 @@ public class Main extends JavaPlugin implements Listener {
             debug("Metrics have been disabled in the config.yml. Guess we won't support all this hard work today!");
         }
 
-        taskresetid = startStatResetTimer();
-        playerupdateid = startPlayerUpdateTimer();
+        // Anyone already online (an improper reload) still needs a play time session opened,
+        // or nothing would accrue for them until they reconnected.
+        for (Player online : players) {
+            Timer.startSession(online.getUniqueId());
+        }
+
+        taskresettimer = startStatResetTimer();
+        playerupdatetimer = startPlayerUpdateTimer();
 
         mpl.scheduling().asyncScheduler().run(() -> {
             ConnectionOpen coe = new ConnectionOpen();
@@ -292,32 +320,36 @@ public class Main extends JavaPlugin implements Listener {
     }
 
 
-    // Update player file, mostly for accurate playtime's every 10 minutes!
-    private int startPlayerUpdateTimer() {
-        final ScheduledTask playerupdatetime = mpl.scheduling().asyncScheduler().runAtFixedRate(() -> {
-            asyncrunning = true;
+    /*
+      Checkpoints every online player's file so play time survives a crash. A normal quit is
+      always exact; this interval only bounds how much of a session is lost if the server dies
+      without a shutdown. It used to be hardcoded to 12 seconds despite the comment claiming
+      ten minutes, which meant a write per online player every 12 seconds.
+     */
+    private ScheduledTask startPlayerUpdateTimer() {
+        final Duration interval = Duration.ofSeconds(playerupdateseconds);
+        return mpl.scheduling().asyncScheduler().runAtFixedRate(() -> {
             debug("Updating any online players data files...");
             for (Player p : Bukkit.getOnlinePlayers()) {
                 updateFile(p, false);
             }
-            asyncrunning = false;
             UpdatedPlayerStats ups = new UpdatedPlayerStats();
             Bukkit.getPluginManager().callEvent(ups);
-        }, Duration.ofMillis(12000),  Duration.ofMillis(12000));
-        return playerupdatetime.hashCode();
+        }, interval, interval);
     }
 
     // Reset Stats every 12 hours
-    private int startStatResetTimer() {
-        final ScheduledTask resetstatstimer =  mpl.scheduling().asyncScheduler().runAtFixedRate(() -> {
+    private ScheduledTask startStatResetTimer() {
+        // Was 864000ms (14 minutes), not the 12 hours the comment promised.
+        final Duration interval = Duration.ofHours(12);
+        return mpl.scheduling().asyncScheduler().runAtFixedRate(() -> {
             debug("Resetting the puuids debug statistics, it's been over 12 hours...");
             setTimeMS = 0;
-            setTimes = 0;
-            getTimes = 0;
+            setTimes.set(0);
+            getTimes.set(0);
             qTimesMS = 0;
             setQRequests = 0;
-        }, Duration.ofMillis(864000), Duration.ofMillis(864000));
-        return resetstatstimer.hashCode();
+        }, interval, interval);
     }
     // End of 12 hour Stat Reset timer
 
@@ -335,21 +367,33 @@ public class Main extends JavaPlugin implements Listener {
 
         allowconnections = false;
 
+        // Stop the repeating tasks before flushing, so nothing queues more work behind us.
+        // These used to be cancelled by passing a ScheduledTask's hashCode to the Bukkit
+        // scheduler as if it were a task id, which cancelled nothing of ours (and could well
+        // have cancelled another plugin's task that happened to hold that id).
+        if (taskresettimer != null) {
+            taskresettimer.cancel();
+            taskresettimer = null;
+        }
+        if (playerupdatetimer != null) {
+            playerupdatetimer.cancel();
+            playerupdatetimer = null;
+        }
+
         for (Player p : Bukkit.getOnlinePlayers()) {
-            Cooldowns.clearAll(p);
+            Cooldowns.clearAll(p.getUniqueId());
             updateFile(p, true);
         }
 
         Timer.stopTimer();
-        getServer().getScheduler().cancelTask(taskresetid);
-        getServer().getScheduler().cancelTask(playerupdateid);
         mpl.scheduling().cancelGlobalTasks();
 
         plugins.clear();
+        nameindex.clear();
 
         setTimeMS = 0;
-        setTimes = 0;
-        getTimes = 0;
+        setTimes.set(0);
+        getTimes.set(0);
         qTimesMS = 0;
         setQRequests = 0;
 
@@ -384,18 +428,31 @@ public class Main extends JavaPlugin implements Listener {
         updatecheck = getConfig().getBoolean("Settings.Update-Checking", true);
         Msgs.prefix = getConfig().getString("Settings.Prefix", "&8[&e&lPUUIDs&8]");
 
-        if (getConfig().getLong("Advanced.Save-Rate-Ticks", 10) != 0) {
+        if (getConfig().getLong("Advanced.Save-Rate-Ticks", 10) > 0) {
             Timer.processrate = getConfig().getLong("Advanced.Save-Rate-Ticks", 10);
         } else {
             Timer.processrate = 10;
             getLogger().warning("Save Rate was set to 0 ticks in the config, this will cause damage. Defaulting to 10 ticks.");
         }
 
-        if (getConfig().getLong("Advanced.Max-Processes-Per-Queue", 25) != 0) {
+        if (getConfig().getInt("Advanced.Max-Processes-Per-Queue", 25) > 0) {
             Timer.sizelimit = getConfig().getInt("Advanced.Max-Processes-Per-Queue", 25);
         } else {
-            Timer.processrate = 25;
+            // This used to reset processrate instead of sizelimit, so a queue size of 0 both
+            // kept the broken limit and quietly changed the save rate.
+            Timer.sizelimit = 25;
             getLogger().warning("Max-Processes-Per-Queue was set to 0 in the config, this will prevent data from being set. Defaulting to 25.");
+        }
+
+        playerupdateseconds = Math.max(5, getConfig().getInt("Advanced.Player-Update-Seconds", 300));
+
+        // Picks up a changed Save-Rate-Ticks on /puuids reload. No-op before the timer exists.
+        Timer.startTimer();
+
+        if (playerupdatetimer != null) {
+            // Only on reload; during onEnable the timer hasn't been created yet.
+            playerupdatetimer.cancel();
+            playerupdatetimer = startPlayerUpdateTimer();
         }
 
         if (isFullySupported) {
@@ -506,16 +563,52 @@ public class Main extends JavaPlugin implements Listener {
         return Timer.queueSet(plname, uuid, "PUUIDS_SET_AS_ALL_NULL", null);
     }
 
-    public String nametoUUID(String inputsearch) {
-        File folder = new File(this.getDataFolder(), File.separator + "Data");
+    /** Remembers a username so the next lookup for it doesn't have to scan the data folder. */
+    void indexName(String name, String uuid) {
+        if (name == null || uuid == null) {
+            return;
+        }
+        nameindex.put(name.toLowerCase(Locale.ROOT), uuid);
+    }
 
-        for (File AllData : Objects.requireNonNull(folder.listFiles())) {
+    /*
+      This used to load and parse every file in the data folder on the calling thread, which is
+      the main thread for /puuids ontime <player> and for the PUUIDS.getUUID(name) API. On a
+      server with thousands of player files that's a visible freeze on every single call.
+      The index answers the common case outright; a miss still falls back to the full scan.
+     */
+    public String nametoUUID(String inputsearch) {
+        if (inputsearch == null) {
+            return "0";
+        }
+
+        final String key = inputsearch.toLowerCase(Locale.ROOT);
+        final File folder = new File(this.getDataFolder(), File.separator + "Data");
+
+        final String cached = nameindex.get(key);
+        if (cached != null) {
+            // Confirm against the one file it points at, in case they've since changed name.
+            final File f = new File(folder, File.separator + cached + ".yml");
+            if (f.exists() && inputsearch.equalsIgnoreCase(YamlConfiguration.loadConfiguration(f).getString("Username"))) {
+                return cached;
+            }
+            nameindex.remove(key, cached);
+        }
+
+        final File[] files = folder.exists() ? folder.listFiles() : null;
+        if (files == null) {
+            return "0";
+        }
+
+        for (File AllData : files) {
             File f = new File(AllData.getPath());
 
             FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
 
             String playername = setcache.getString("Username");
             String UUID = setcache.getString("UUID");
+
+            indexName(playername, UUID);
 
             if (inputsearch.equalsIgnoreCase(playername)) {
                 return UUID;
@@ -562,25 +655,35 @@ public class Main extends JavaPlugin implements Listener {
         return setcache.getLong("Last-On");
     }
 
+    /**
+     * Total play time in seconds, including the part of a live session that hasn't been
+     * written to file yet. Without that, asking an online player how long they'd played
+     * reported whatever was last checkpointed rather than the truth.
+     */
     public long getPlayTime(String uuid) {
+        if (uuid == null) {
+            return 0;
+        }
+
+        long played = 0;
+
         File cache = new File(this.getDataFolder(), File.separator + "Data");
-
-        if (!cache.exists()) {
-            return 0;
-        }
-
         File f = new File(cache, File.separator + uuid + ".yml");
-        FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
 
-        if (!f.exists()) {
-            return 0;
+        if (cache.exists() && f.exists()) {
+            FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
+            if (setcache.contains("Time-Played")) {
+                played = setcache.getLong("Time-Played");
+            }
         }
 
-        if (!setcache.contains("Time-Played")) {
-            return 0;
+        try {
+            played += Timer.liveSessionSeconds(UUID.fromString(uuid));
+        } catch (IllegalArgumentException notAUuid) {
+            // Nothing live to add for a malformed UUID.
         }
 
-        return setcache.getLong("Time-Played");
+        return played;
     }
 
     public String getPlayerIP(String uuid) {
@@ -617,7 +720,7 @@ public class Main extends JavaPlugin implements Listener {
 
 
     private void updateFile(Player p, boolean quit) {
-        Timer.updateSystem.put(p, quit);
+        Timer.queuePlayerUpdate(p, quit);
     }
 
     /*
@@ -639,10 +742,16 @@ public class Main extends JavaPlugin implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onJoin(PlayerJoinEvent e) {
+        final Player joining = e.getPlayer();
+
+        // Open the play time session here and unconditionally: it has to happen even when the
+        // file refresh below is skipped by the cooldown, or a quick reconnect accrues nothing.
+        Timer.startSession(joining.getUniqueId());
+
         mpl.scheduling().asyncScheduler().run(() -> {
-            Player p = e.getPlayer();
+            Player p = joining;
             UUID uuid = p.getUniqueId();
-            if (Cooldowns.joined.contains(uuid)) {
+            if (Cooldowns.recentlyJoined(uuid)) {
                 debug(p.getName() + "'s file won't be refreshed, it was updated less than 60s ago. [Join]");
                 return;
             }
@@ -678,14 +787,14 @@ public class Main extends JavaPlugin implements Listener {
         Player p = e.getPlayer();
         UUID uuid = p.getUniqueId();
 
-        if (!Cooldowns.joined.contains(uuid)) {
-            updateFile(p, true);
-            Cooldowns.justJoined(uuid);
-        } else {
-            debug(p.getName() + "'s file won't be refreshed, it was updated less than 60s ago. [Quit]");
-        }
-
-        Cooldowns.confirmall.remove(p);
+        /*
+          The quit write is never skipped any more. It used to be suppressed whenever the player
+          had joined within the cooldown window, which threw away the whole session: the quit
+          write is the only thing that closes the session and banks the time.
+         */
+        updateFile(p, true);
+        Cooldowns.justJoined(uuid);
+        Cooldowns.clearConfirm(uuid);
     }
 
     private String randomString() {
@@ -853,8 +962,8 @@ public class Main extends JavaPlugin implements Listener {
                             Msgs.send(sender, "&fBukkit Version: &e" + version);
                         }
                     }
-                    Msgs.send(sender, "&fTotal Sets: &e" + setTimes);
-                    Msgs.send(sender, "&fTotal Gets: &e" + getTimes);
+                    Msgs.send(sender, "&fTotal Sets: &e" + setTimes.get());
+                    Msgs.send(sender, "&fTotal Gets: &e" + getTimes.get());
 
                     try {
                         Runtime r = Runtime.getRuntime();
@@ -909,23 +1018,25 @@ public class Main extends JavaPlugin implements Listener {
                     return true;
                 }
 
-                if (!Cooldowns.confirmall.containsKey(p)) {
+                String pendingkey = Cooldowns.confirmKey(p.getUniqueId());
+
+                if (pendingkey == null) {
                     String key = randomString();
                     thinking(p);
                     Msgs.sendPrefix(p, "&c&lARE YOU SURE? &fThis may corrupt data. Do &7&l/puuids togglesave " + key + "&f in 10s to confirm.");
-                    Cooldowns.confirm(p, key);
+                    Cooldowns.confirm(p.getUniqueId(), key);
                     return true;
                 } else {
                     // Has reset all confirmation key active v v v
                     if (args.length == 1) {
-                        Msgs.sendPrefix(p, "&c&lARE YOU SURE? &fType &7&l/puuids togglesave " + Cooldowns.confirmall.get(p) + "&f to confirm.");
+                        Msgs.sendPrefix(p, "&c&lARE YOU SURE? &fType &7&l/puuids togglesave " + pendingkey + "&f to confirm.");
                         thinking(p);
                         return true;
                     } else {
-                        if (!args[1].equalsIgnoreCase(Cooldowns.confirmall.get(p))) {
+                        if (!args[1].equalsIgnoreCase(pendingkey)) {
                             bass(p);
                             Msgs.sendPrefix(p, "&6&lToggle Saving Canceled. &fThat was an invalid confirmation key.");
-                            Cooldowns.confirmall.remove(p);
+                            Cooldowns.clearConfirm(p.getUniqueId());
                             return true;
                         }
                     }
@@ -942,7 +1053,7 @@ public class Main extends JavaPlugin implements Listener {
                 }
                 Msgs.send(p, "&7");
                 pop(p);
-                Cooldowns.confirmall.remove(p);
+                Cooldowns.clearConfirm(p.getUniqueId());
                 return true;
             }
 
@@ -956,7 +1067,7 @@ public class Main extends JavaPlugin implements Listener {
                     return true;
                 }
 
-                if (!Cooldowns.canRunLargeTask) {
+                if (!Cooldowns.canRunLargeTask()) {
                     bass(sender);
                     Msgs.sendPrefix(sender, "&6&lPlease Wait. &fRunning large tasks this quickly can have a negative impact on your server's performance.");
                     return true;
@@ -1039,23 +1150,25 @@ public class Main extends JavaPlugin implements Listener {
                         return true;
                     }
 
-                    if (!Cooldowns.confirmall.containsKey(p)) {
+                    String pendingkey = Cooldowns.confirmKey(p.getUniqueId());
+
+                    if (pendingkey == null) {
                         String key = randomString();
                         thinking(p);
                         Msgs.sendPrefix(p, "&c&lARE YOU SURE? &fThis will erase ALL player data from your PUUID's data folder. Do &7&l/puuids reset all " + key + "&f in 10s to confirm.");
-                        Cooldowns.confirm(p, key);
+                        Cooldowns.confirm(p.getUniqueId(), key);
                         return true;
                     } else {
                         // Has reset all confirmation key active v v v
                         if (args.length == 2) {
-                            Msgs.sendPrefix(p, "&c&lARE YOU SURE? &fType &7&l/puuids reset all " + Cooldowns.confirmall.get(p) + "&f to confirm.");
+                            Msgs.sendPrefix(p, "&c&lARE YOU SURE? &fType &7&l/puuids reset all " + pendingkey + "&f to confirm.");
                             thinking(p);
                             return true;
                         } else {
-                            if (!args[2].equalsIgnoreCase(Cooldowns.confirmall.get(p))) {
+                            if (!args[2].equalsIgnoreCase(pendingkey)) {
                                 bass(p);
                                 Msgs.sendPrefix(p, "&6&lReset Canceled. &fThat was an invalid reset key.");
-                                Cooldowns.confirmall.remove(p);
+                                Cooldowns.clearConfirm(p.getUniqueId());
                                 return true;
                             }
                         }
@@ -1141,7 +1254,7 @@ public class Main extends JavaPlugin implements Listener {
 
                 if (sender instanceof Player) {
                     Player p = (Player) sender;
-                    if (Cooldowns.ontime.contains(p.getUniqueId())) {
+                    if (Cooldowns.onTimeCooling(p.getUniqueId())) {
                         Msgs.sendPrefix(sender, "&c&lSlow Down. &fPlease wait before checking that again.");
                         bass(p);
                         return true;
@@ -1186,7 +1299,7 @@ public class Main extends JavaPlugin implements Listener {
                 } else {
                     Msgs.send(sender, "&8&l> &fHooked Plugins: &7&l0");
                 }
-                if (setTimeMS == 0 && setTimes == 0) {
+                if (setTimeMS == 0 && setTimes.get() == 0) {
                     Msgs.send(sender, "&8&l> &fSet Information: &7&l--ms");
                 } else {
                     Msgs.send(sender, "&8&l> &fSet Information: &e&l" + setTimeMS + "ms");
@@ -1202,8 +1315,8 @@ public class Main extends JavaPlugin implements Listener {
                     }
                 }
 
-                Msgs.send(sender, "&8&l> &fSet Requests: &e&l" + setTimes);
-                Msgs.send(sender, "&8&l> &fGet Requests: &e&l" + getTimes);
+                Msgs.send(sender, "&8&l> &fSet Requests: &e&l" + setTimes.get());
+                Msgs.send(sender, "&8&l> &fGet Requests: &e&l" + getTimes.get());
 
                 if (status) {
                     if (setTimeMS < 10 || qTimesMS < 650) {

--- a/src/com/zachduda/puuids/Timer.java
+++ b/src/com/zachduda/puuids/Timer.java
@@ -1,12 +1,5 @@
 package com.zachduda.puuids;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-
-import java.time.Duration;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import com.zachduda.puuids.api.OnNewFile;
 import com.zachduda.puuids.api.TimerSaved;
 import org.bukkit.Bukkit;
@@ -16,251 +9,386 @@ import org.bukkit.entity.Player;
 import space.arim.morepaperlib.scheduling.ScheduledTask;
 
 import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Timer {
+    // How often the queue is drained, in server ticks (Advanced.Save-Rate-Ticks).
     static long processrate = 10;
+    // Most queued plugin writes handled in a single run (Advanced.Max-Processes-Per-Queue).
     static int sizelimit = 25;
-    //               Player,  Quit?
-    static Multimap<Player, Boolean> updateSystem = Multimaps.newMultimap(
-    new ConcurrentHashMap<>(), 
-    ConcurrentLinkedQueue::new
-);
+
     private static final Main plugin = Main.getPlugin(Main.class);
-    private static boolean busy = false;
-    private static int taskid = 1;
-    //                                 UUID   PLUGIN   PATH     DATA    ID
-    private static final ArrayList<Quartet<String, String, String, Object, Integer>> rawdata = new ArrayList<>();
-    final static ScheduledTask timer = plugin.mpl.scheduling().asyncScheduler().runAtFixedRate(() -> {
-        final int size = getQSize();
-        final int ssize = updateSystem.size();
-        if ((ssize == 0 && size == 0) || busy || plugin.asyncrunning) {
+    private static final AtomicBoolean busy = new AtomicBoolean(false);
+    private static final AtomicInteger taskid = new AtomicInteger(1);
+
+    // puuids' own player file updates (username / ip / last-on / play time).
+    private static final ConcurrentLinkedQueue<PlayerUpdate> updateSystem = new ConcurrentLinkedQueue<>();
+
+    //                                                UUID    PLUGIN   PATH    DATA     ID
+    private static final ConcurrentLinkedQueue<Quartet<String, String, String, Object, Integer>> rawdata = new ConcurrentLinkedQueue<>();
+    // ConcurrentLinkedQueue#size() walks the whole queue, so the depth is tracked separately.
+    private static final AtomicInteger rawsize = new AtomicInteger();
+
+    /*
+      Play time is only ever credited for the span between two checkpoints of a session that
+      we watched begin. Last-On can't be used for this: it is also refreshed for players who
+      are merely seen, so reading it back as "when they joined" credited offline time as play
+      time. Anything not in this map simply isn't accruing.
+     */
+    private static final ConcurrentHashMap<UUID, Long> sessions = new ConcurrentHashMap<>();
+
+    private static volatile ScheduledTask timer;
+    private static volatile long scheduledrate = -1;
+
+    /**
+     * Starts (or reschedules, after a config reload) the queue timer.
+     * Called once the configuration has been read so Save-Rate-Ticks is actually honoured.
+     */
+    static synchronized void startTimer() {
+        final long rate = Math.max(1L, processrate) * 50L; // ticks -> ms
+
+        if (timer != null) {
+            if (rate == scheduledrate) {
+                return;
+            }
+            timer.cancel();
+        }
+
+        scheduledrate = rate;
+        timer = plugin.mpl.scheduling().asyncScheduler().runAtFixedRate(
+                Timer::process, Duration.ofMillis(rate), Duration.ofMillis(rate));
+    }
+
+    /**
+     * Drains both queues and writes each affected player file exactly once.
+     * Every path out of here has to clear {@code busy}, or saving stops for good.
+     */
+    private static void process() {
+        if (plugin.asyncrunning || (updateSystem.isEmpty() && rawdata.isEmpty())) {
             return;
         }
 
-        busy = true;
-
-        final File cache = new File(plugin.getDataFolder(), File.separator + "Data");
-
-        // internal puuids updates
-        while (!updateSystem.isEmpty()) {
-            final Player p = updateSystem.keys().iterator().next();
-            final boolean quit = Boolean.TRUE.equals(updateSystem.get(p).iterator().next());
-
-            assert p != null;
-            final String uuid = p.getUniqueId().toString();
-            final String name = p.getName();
-
-            boolean isnewfile = false;
-
-            File f = new File(cache, File.separator + uuid + ".yml");
-            FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
-
-            if (!f.exists()) {
-                try {
-                    setcache.save(f);
-                    isnewfile = true;
-                } catch (Exception err) {
-                }
-            }
-
-            final long now = System.currentTimeMillis();
-            String IPAdd = Objects.requireNonNull(p.getAddress()).getAddress().toString().replace(p.getAddress().getHostString() + "/", "").replace("/", "");
-
-            setcache.set("UUID", uuid);
-            setcache.set("IP", IPAdd);
-            setcache.set("Username", name);
-
-            if (quit) {
-                final long joined = setcache.getLong("Last-On");
-                final long current = setcache.getLong("Time-Played");
-                final long sub = (now - joined);
-                final long secs = sub / 1000;
-                final long result = (current + secs);
-                setcache.set("Time-Played", result);
-                plugin.debug("Joined: " + joined + "   Current: " + current + "  Sub: " + sub + "  Secs: " + secs + "  Result: " + result);
-            }
-
-            setcache.set("Last-On", now);
-
-            try {
-                setcache.save(f);
-            } catch (Exception err) {
-                plugin.debug("Error. Was unable to save " + name + "'s file for puuids System update: ");
-                err.printStackTrace();
-            }
-
-            plugin.debug("Updated " + name + "'s player data.");
-            plugin.setTimes++;
-            updateSystem.remove(p, quit);
-
-            if (isnewfile) {
-                OnNewFile fse = new OnNewFile(p);
-                Bukkit.getPluginManager().callEvent(fse);
-            }
+        if (!busy.compareAndSet(false, true)) {
+            return; // A previous run is still going; it will pick these up.
         }
-        // end of system updates --------------
-
 
         final long start = System.currentTimeMillis();
-        int processed = 0; // Processed non-puuids requests
-        plugin.setQRequests = size;
+        try {
+            final Map<String, Batch> work = new LinkedHashMap<>();
 
-        while (!rawdata.isEmpty()) {
-            if (processed > sizelimit) {
+            PlayerUpdate update;
+            while ((update = updateSystem.poll()) != null) {
+                work.computeIfAbsent(update.uuid, k -> new Batch()).updates.add(update);
+            }
+
+            int queued = rawsize.get();
+            plugin.setQRequests = queued;
+
+            int processed = 0;
+            while (processed < sizelimit) {
+                Quartet<String, String, String, Object, Integer> data = rawdata.poll();
+                if (data == null) {
+                    break;
+                }
+                rawsize.decrementAndGet();
+                work.computeIfAbsent(data.getUUID(), k -> new Batch()).sets.add(data);
+                processed++;
+            }
+
+            if (processed == sizelimit && !rawdata.isEmpty()) {
                 plugin.debug("Q reached size limit of " + sizelimit + "... sending other updates to next run.");
-                break;
-            }
-            final long startset = System.currentTimeMillis();
-            Quartet<String, String, String, Object, Integer> data = rawdata.get(0);
-            final String uuid = data.getUUID();
-            final String plname = data.getPlugin();
-            final String path = data.getPath();
-            final Object value = data.getData();
-            final int taskid = data.getId();
-
-            File f = new File(cache, File.separator + uuid + ".yml");
-            FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
-
-            if (!f.exists()) {
-                try {
-                    setcache.save(f);
-                } catch (Exception ignored) {
-                    // First creation fail can happen. meh.
-                }
             }
 
-            if (path.equals("PUUIDS_SET_AS_ALL_NULL")) {
-                setcache.set("Plugins." + plname, null);
-            } else {
-                setcache.set("Plugins." + plname + "." + path, value);
+            for (Map.Entry<String, Batch> entry : work.entrySet()) {
+                writeBatch(entry.getKey(), entry.getValue(), true);
             }
-
-            plugin.debug("(" + taskid + ") " + plname + " set " + value + " for " + uuid + " under: " + path);
-
-            try {
-                setcache.save(f);
-                TimerSaved tse = new TimerSaved(plname, uuid, taskid);
-                Bukkit.getServer().getPluginManager().callEvent(tse);
-            } catch (Exception err) {
-                busy = false;
-                if (plugin.debug) {
-                    plugin.getLogger().warning("Unable to save puuids file for user " + plugin.UUIDtoname(uuid) + " in plugin: " + plname);
-                    err.printStackTrace();
-                }
+        } catch (Throwable err) {
+            // Never let a bad file take the whole pipeline down with it.
+            plugin.getLogger().warning("Unexpected error while saving player data: " + err);
+            if (plugin.debug) {
+                err.printStackTrace();
             }
-
-            plugin.setTimeMS = (plugin.setTimeMS + System.currentTimeMillis() - startset) / 2;
-            plugin.setTimes++;
-            processed++;
-            rawdata.remove(data);
+        } finally {
+            busy.set(false);
         }
 
         plugin.qTimesMS = System.currentTimeMillis() - start;
 
         if (plugin.qTimesMS > 650) {
-            plugin.getLogger().warning("Saving player data took " + plugin.qTimesMS + "ms. Try reducding max your task limit!");
+            plugin.getLogger().warning("Saving player data took " + plugin.qTimesMS + "ms. Try reducing your max task limit!");
         }
-        busy = false;
-    }, Duration.ofMillis(processrate), Duration.ofMillis(processrate));
-
-    static int getQSize() {
-        return rawdata.size();
     }
 
-    static int queueSet(String pl, String uuid, String location, Object value) {
-        final int thisid = taskid;
-        taskid += 1;
-        plugin.mpl.scheduling().globalRegionalScheduler().run(() -> { // Ensures running SYNC to place.
-            Quartet<String, String, String, Object, Integer> quart = new Quartet<String, String, String, Object, Integer>(uuid, pl.toUpperCase(), location, value, thisid);
-            rawdata.add(quart);
-        });
-        return thisid;
-    }
+    /**
+     * Applies every queued change for one player to one file, with a single load and a single save.
+     *
+     * @param events whether the OnNewFile / TimerSaved events should be fired (skipped on shutdown).
+     */
+    private static void writeBatch(String uuid, Batch batch, boolean events) {
+        final long startset = System.currentTimeMillis();
+        final File cache = new File(plugin.getDataFolder(), File.separator + "Data");
+        final File f = new File(cache, File.separator + uuid + ".yml");
+        final boolean isnewfile = !f.exists();
 
-    static void stopTimer() {
-        Timer.timer.cancel();
-        final int size = getQSize();
-        final int systemsize = updateSystem.size();
+        final FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
 
-        if (size == 0 && systemsize == 0) {
+        for (PlayerUpdate update : batch.updates) {
+            setcache.set("UUID", update.uuid);
+            setcache.set("Username", update.name);
+            if (update.ip != null) {
+                // A player who has already dropped has no address; keep the last known one.
+                setcache.set("IP", update.ip);
+            }
+            setcache.set("Last-On", update.timestamp);
+
+            if (update.playedSeconds > 0) {
+                final long current = setcache.getLong("Time-Played");
+                setcache.set("Time-Played", current + update.playedSeconds);
+                plugin.debug("Credited " + update.name + " with " + update.playedSeconds + "s of play time (total "
+                        + (current + update.playedSeconds) + "s)" + (update.quit ? " on quit." : "."));
+            }
+        }
+
+        for (Quartet<String, String, String, Object, Integer> data : batch.sets) {
+            final String plname = data.getPlugin();
+            final String path = data.getPath();
+
+            if (path.equals("PUUIDS_SET_AS_ALL_NULL")) {
+                setcache.set("Plugins." + plname, null);
+            } else {
+                setcache.set("Plugins." + plname + "." + path, data.getData());
+            }
+
+            plugin.debug("(" + data.getId() + ") " + plname + " set " + data.getData() + " for " + uuid + " under: " + path);
+        }
+
+        if (!save(setcache, f)) {
             return;
         }
 
-        final File cache = new File(plugin.getDataFolder(), File.separator + "Data");
+        if (!batch.updates.isEmpty()) {
+            plugin.setTimes.incrementAndGet();
+            plugin.indexName(batch.updates.get(batch.updates.size() - 1).name, uuid);
+        }
 
-        if (systemsize > 0) {
-            for (int i = 0; i < systemsize; i++) {
-                final Player p = updateSystem.keys().iterator().next();
-                final boolean quit = Boolean.TRUE.equals(updateSystem.get(p).iterator().next());
+        if (!batch.sets.isEmpty()) {
+            plugin.setTimeMS = (plugin.setTimeMS + System.currentTimeMillis() - startset) / 2;
+            plugin.setTimes.addAndGet(batch.sets.size());
+        }
 
-                assert p != null;
-                final String uuid = p.getUniqueId().toString();
-                final String name = p.getName();
+        if (!events) {
+            return;
+        }
 
-                File f = new File(cache, File.separator + uuid + ".yml");
-                FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
-
-                if (!f.exists()) {
-                    try {
-                        setcache.save(f);
-                    } catch (Exception ignored) {
-                        // Forced mostly so we don't care.
-                    }
+        if (isnewfile) {
+            for (PlayerUpdate update : batch.updates) {
+                if (update.player != null) {
+                    Bukkit.getPluginManager().callEvent(new OnNewFile(update.player));
+                    break;
                 }
-
-                final long lefttime = System.currentTimeMillis();
-
-                String IPAdd = Objects.requireNonNull(p.getAddress()).getAddress().toString().replace(p.getAddress().getHostString() + "/", "").replace("/", "");
-
-                setcache.set("UUID", uuid);
-                setcache.set("IP", IPAdd);
-                setcache.set("Username", name);
-                setcache.set("Last-On", lefttime);
-
-                if (quit) {
-                    final long joined = setcache.getLong("Last-On");
-                    final long current = setcache.getLong("Time-Played");
-                    setcache.set("Time-Played", ((current) + ((lefttime - joined) / 1000)));
-                }
-
-                try {
-                    setcache.save(f);
-                } catch (Exception err) {
-                    plugin.debug("Error. Was unable to save " + name + "'s file for puuids System update: ");
-                    err.printStackTrace();
-                }
-
-                plugin.debug("Updated " + name + "'s player data.");
-                updateSystem.remove(p, quit);
             }
         }
 
-        if (size > 0) {
-            plugin.getLogger().info("Saving " + size + " leftover tasks...");
+        for (Quartet<String, String, String, Object, Integer> data : batch.sets) {
+            Bukkit.getServer().getPluginManager().callEvent(new TimerSaved(data.getPlugin(), uuid, data.getId()));
+        }
+    }
 
-            for (int i = 0; i < size; i++) {
-                Quartet<String, String, String, Object, Integer> data = rawdata.get(0);
-                final String uuid = data.getUUID();
-                final String plname = data.getPlugin();
-                final String path = data.getPath();
-                final Object value = data.getData();
-
-                File f = new File(cache, File.separator + uuid + ".yml");
-                FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
-
-                setcache.set("Plugins." + plname + "." + path, value);
-                plugin.debug("(# " + data.getId() + ") Set " + value + " for " + uuid + " under: " + path);
-
-                try {
-                    setcache.save(f);
-                } catch (Exception err) {
-                    plugin.getLogger().warning("Unable to save puuids file for user " + plugin.UUIDtoname(uuid) + " in plugin: " + plname);
-                }
-
-                rawdata.remove(data);
+    /**
+     * Writes to a sibling temp file and moves it into place, so a crash mid-write can't
+     * leave a player with a half-written (and therefore unreadable) data file.
+     */
+    private static boolean save(FileConfiguration config, File target) {
+        final File temp = new File(target.getParentFile(), target.getName() + ".tmp");
+        try {
+            config.save(temp);
+            try {
+                Files.move(temp.toPath(), target.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (Exception atomicUnsupported) {
+                Files.move(temp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
+            return true;
+        } catch (Exception err) {
+            plugin.getLogger().warning("Unable to save puuids file " + target.getName() + ": " + err);
+            if (plugin.debug) {
+                err.printStackTrace();
+            }
+            //noinspection ResultOfMethodCallIgnored
+            temp.delete();
+            return false;
+        }
+    }
+
+    /**
+     * Opens a play time session. Called the moment a player joins, before any of the
+     * asynchronous join handling, so a session is never missed.
+     */
+    static void startSession(UUID uuid) {
+        sessions.put(uuid, System.currentTimeMillis());
+    }
+
+    /**
+     * Seconds of the current session that haven't been written to file yet.
+     * Returns 0 for anyone who isn't currently accruing.
+     */
+    static long liveSessionSeconds(UUID uuid) {
+        final Long anchor = sessions.get(uuid);
+        if (anchor == null) {
+            return 0;
+        }
+        return Math.max(0L, (System.currentTimeMillis() - anchor) / 1000L);
+    }
+
+    /**
+     * Snapshots a player and queues their file update.
+     * <p>
+     * Everything is read here, on the thread that still has a valid Player, rather than later
+     * on the writer thread where a quitting player's address (and name) may already be gone.
+     */
+    static void queuePlayerUpdate(Player p, boolean quit) {
+        if (p == null) {
+            return;
+        }
+
+        final long now = System.currentTimeMillis();
+        final UUID id = p.getUniqueId();
+        final long[] credited = {0L};
+
+        sessions.compute(id, (key, anchor) -> {
+            if (anchor == null) {
+                // Not accruing yet (server just started, or we never saw them join).
+                return quit ? null : now;
+            }
+            final long secs = Math.max(0L, (now - anchor) / 1000L);
+            credited[0] = secs;
+            // Advance by whole seconds only, so the sub-second remainder isn't dropped
+            // every single checkpoint.
+            return quit ? null : anchor + (secs * 1000L);
+        });
+
+        updateSystem.add(new PlayerUpdate(p, id.toString(), p.getName(), readIP(p), now, credited[0], quit));
+    }
+
+    private static String readIP(Player p) {
+        try {
+            final InetSocketAddress address = p.getAddress();
+            if (address == null || address.getAddress() == null) {
+                return null;
+            }
+            return address.getAddress().getHostAddress();
+        } catch (Exception err) {
+            return null;
+        }
+    }
+
+    static int getQSize() {
+        return rawsize.get();
+    }
+
+    static int queueSet(String pl, String uuid, String location, Object value) {
+        if (uuid == null) {
+            return 0;
+        }
+
+        final int thisid = taskid.getAndIncrement();
+        rawdata.add(new Quartet<>(uuid, pl.toUpperCase(), location, value, thisid));
+        rawsize.incrementAndGet();
+        return thisid;
+    }
+
+    /**
+     * Cancels the timer and flushes whatever is still queued. Runs on the shutdown thread.
+     */
+    static void stopTimer() {
+        final ScheduledTask running = timer;
+        if (running != null) {
+            running.cancel();
+            timer = null;
+            scheduledrate = -1;
+        }
+
+        // Wait briefly for an in-flight run so the same file isn't written from two threads.
+        for (int i = 0; i < 100 && busy.get(); i++) {
+            try {
+                Thread.sleep(10L);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        final int leftover = rawsize.get();
+        if (leftover == 0 && updateSystem.isEmpty()) {
+            return;
+        }
+
+        if (leftover > 0) {
+            plugin.getLogger().info("Saving " + leftover + " leftover tasks...");
+        }
+
+        final Map<String, Batch> work = new LinkedHashMap<>();
+
+        PlayerUpdate update;
+        while ((update = updateSystem.poll()) != null) {
+            work.computeIfAbsent(update.uuid, k -> new Batch()).updates.add(update);
+        }
+
+        Quartet<String, String, String, Object, Integer> data;
+        while ((data = rawdata.poll()) != null) {
+            rawsize.decrementAndGet();
+            work.computeIfAbsent(data.getUUID(), k -> new Batch()).sets.add(data);
+        }
+
+        for (Map.Entry<String, Batch> entry : work.entrySet()) {
+            try {
+                // No events: the plugin manager is on its way down with us.
+                writeBatch(entry.getKey(), entry.getValue(), false);
+            } catch (Exception err) {
+                plugin.getLogger().warning("Unable to save leftover puuids data for " + entry.getKey() + ": " + err);
+            }
+        }
+
+        sessions.clear();
+    }
+
+    /** Everything queued for a single player file. */
+    private static final class Batch {
+        private final List<PlayerUpdate> updates = new ArrayList<>(1);
+        private final List<Quartet<String, String, String, Object, Integer>> sets = new ArrayList<>(1);
+    }
+
+    /** An immutable snapshot of a player, taken while they were still valid to read. */
+    private static final class PlayerUpdate {
+        private final Player player;
+        private final String uuid;
+        private final String name;
+        private final String ip;
+        private final long timestamp;
+        private final long playedSeconds;
+        private final boolean quit;
+
+        private PlayerUpdate(Player player, String uuid, String name, String ip,
+                             long timestamp, long playedSeconds, boolean quit) {
+            this.player = player;
+            this.uuid = uuid;
+            this.name = name;
+            this.ip = ip;
+            this.timestamp = timestamp;
+            this.playedSeconds = playedSeconds;
+            this.quit = quit;
         }
     }
 }

--- a/src/com/zachduda/puuids/Updater.java
+++ b/src/com/zachduda/puuids/Updater.java
@@ -56,7 +56,10 @@ public class Updater {
                                 final String vs = ((String) object.get("tag_name")).replace("v", "");
                                 final Boolean prerelease = ((Boolean) object.get("prerelease"));
                                 if (!prerelease) {
-                                    if (!localPluginVersion.equalsIgnoreCase(vs) && localPluginVersion.equalsIgnoreCase("v4.14.5")) {
+                                    // The second half of this used to require the local version to
+                                    // literally equal "v4.14.5", so no release could ever be
+                                    // reported as an update.
+                                    if (!localPluginVersion.equalsIgnoreCase(vs)) {
                                         foundOutdated.set(true);
                                         foundVersion = vs;
                                     }
@@ -78,6 +81,10 @@ public class Updater {
 
                     if (foundOutdated.get()) {
                         final String posted = foundVersion;
+                        // These back the in-game notice on join, which never fired because
+                        // nothing ever set them.
+                        outdated = true;
+                        posted_version = posted;
                         morePaperLib.scheduling().globalRegionalScheduler().run(() -> {
                             Bukkit.getServer().getConsoleSender().sendMessage(
                                     ChatColor.translateAlternateColorCodes('&',

--- a/src/com/zachduda/puuids/api/PUUIDS.java
+++ b/src/com/zachduda/puuids/api/PUUIDS.java
@@ -2,7 +2,6 @@ package com.zachduda.puuids.api;
 
 import com.google.common.io.Files;
 import com.zachduda.puuids.Main;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -76,44 +75,52 @@ public class PUUIDS {
         return plugin.getPlayTime(uuid);
     }
 
+    /**
+     * Play time as a human readable string.
+     * <p>
+     * Time-Played is stored in seconds, so the value used to be divided by 100 for no reason
+     * before formatting: every play time shown was 100x too small.
+     */
     public static String getFormatedPlayTime(String uuid) {
-        long time = getPlayTime(uuid);
-        String ans = secsToFormatTime(time/100);
-        wasGet();
-        return ans;
+        return secsToFormatTime(getPlayTime(uuid));
     }
 
+    /**
+     * Formats a number of seconds, keeping the two largest useful units so that, say,
+     * 3 days and 23 hours doesn't simply read "3 days".
+     */
     public static String secsToFormatTime(long secs) {
-        if (secs == 0) {
+        if (secs <= 0) {
             return "Nothing Yet!";
-        } else if (secs < 60) {
-            if (secs == 1) {
-                return secs + " second";
-            } else {
-                return secs + " seconds";
-            }
-        } else if (secs < 3600) {
-            final long min = secs / 60;
-            if (min == 1) {
-                return min + " minute";
-            } else {
-                return min + " minutes";
-            }
-        } else if (secs < 86400) {
-            final long hours = secs / 3600;
-            if (hours == 1) {
-                return hours + " hour";
-            } else {
-                return hours + " hours";
-            }
-        } else {
-            final long days = secs / 86400;
-            if (days == 1) {
-                return days + " day";
-            } else {
-                return days + " days";
-            }
         }
+
+        if (secs < 60) {
+            return plural(secs, "second");
+        }
+
+        if (secs < 3600) {
+            return join(plural(secs / 60, "minute"), plural(secs % 60, "second"));
+        }
+
+        if (secs < 86400) {
+            return join(plural(secs / 3600, "hour"), plural((secs % 3600) / 60, "minute"));
+        }
+
+        return join(plural(secs / 86400, "day"), plural((secs % 86400) / 3600, "hour"));
+    }
+
+    private static String plural(long amount, String unit) {
+        if (amount == 0) {
+            return null;
+        }
+        return amount + " " + unit + (amount == 1 ? "" : "s");
+    }
+
+    private static String join(String largest, String remainder) {
+        if (remainder == null) {
+            return largest;
+        }
+        return largest + ", " + remainder;
     }
 
     public static String getString(Plugin pl, String uuid, String location) {
@@ -156,7 +163,7 @@ public class PUUIDS {
 
         ArrayList<String> allplayers = new ArrayList<>();
 
-        for (String playeruuid : Objects.requireNonNull(getAllPlayerUUIDs(pl, quickmode))) {
+        for (String playeruuid : getAllPlayerUUIDs(pl, quickmode)) {
             File f = new File(cache, File.separator + playeruuid + ".yml");
             FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
 
@@ -175,7 +182,7 @@ public class PUUIDS {
 
         ArrayList<String> allplayers = new ArrayList<>();
 
-        for (String playeruuid : Objects.requireNonNull(getAllPlayerUUIDs(pl, quickmode))) {
+        for (String playeruuid : getAllPlayerUUIDs(pl, quickmode)) {
             File f = new File(cache, File.separator + playeruuid + ".yml");
             FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
 
@@ -280,18 +287,17 @@ public class PUUIDS {
     }
 
     public static ArrayList<String> getAllPlayerNames(Plugin pl) {
-        String plname = pl.getName();
+        ArrayList<String> allplayers = new ArrayList<>();
+
         if (!plugin.getPlugins().containsKey(pl)) {
-            return null;
+            return allplayers;
         }
 
         // Gets the player names of all we have record of.
 
         File cache = new File(plugin.getDataFolder(), File.separator + "Data");
 
-        ArrayList<String> allplayers = new ArrayList<>();
-
-        for (File cachefile : Objects.requireNonNull(cache.listFiles())) {
+        for (File cachefile : listData(cache)) {
             String path = cachefile.getPath();
 
             if (Files.getFileExtension(path).equalsIgnoreCase("yml")) {
@@ -305,17 +311,19 @@ public class PUUIDS {
     }
 
     public static ArrayList<String> getAllPlayerUUIDs(Plugin pl, boolean quickmode) {
+        ArrayList<String> allplayers = new ArrayList<>();
+
+        // Returns an empty list rather than null: callers were passing this straight into a
+        // for-each wrapped in requireNonNull, so an unregistered plugin threw instead of no-oping.
         if (!plugin.getPlugins().containsKey(pl)) {
-            return null;
+            return allplayers;
         }
 
         // Gets a list of all the uuids we have a record of.
 
         File cache = new File(plugin.getDataFolder(), File.separator + "Data");
 
-        ArrayList<String> allplayers = new ArrayList<>();
-
-        for (File cachefile : Objects.requireNonNull(cache.listFiles())) {
+        for (File cachefile : listData(cache)) {
             String path = cachefile.getPath();
 
             if (Files.getFileExtension(path).equalsIgnoreCase("yml")) {
@@ -330,6 +338,12 @@ public class PUUIDS {
         }
         wasGet();
         return allplayers;
+    }
+
+    /** listFiles() returns null for a folder that doesn't exist yet, which is not an error here. */
+    private static File[] listData(File cache) {
+        final File[] files = cache.isDirectory() ? cache.listFiles() : null;
+        return files == null ? new File[0] : files;
     }
 
     public static int setLocation(Plugin pl, String uuid, String location, Location input) {
@@ -573,7 +587,8 @@ public class PUUIDS {
         }
 
         List<Integer> input = getIntList(pl, uuid, location);
-        input.add(add);
+        // Was input.add(add): this method appended instead of removing.
+        input.remove(Integer.valueOf(add));
         return plugin.set(pl, uuid, location, input);
     }
     // End of List Add
@@ -631,20 +646,21 @@ public class PUUIDS {
 
         int total = 0;
 
-        for (String playeruuid : Objects.requireNonNull(getAllPlayerUUIDs(pl, false))) {
+        /*
+          Each missing default now goes through the plugin's own async queue. It used to schedule
+          one main-thread task per player file, each of which loaded and saved a file on the main
+          thread - the exact thing this plugin exists to avoid - and the Bukkit scheduler it used
+          isn't available on Folia at all.
+         */
+        for (String playeruuid : getAllPlayerUUIDs(pl, false)) {
             try {
                 File f = new File(cache, File.separator + playeruuid + ".yml");
                 FileConfiguration setcache = YamlConfiguration.loadConfiguration(f);
-                Bukkit.getScheduler().runTask(plugin, () -> {
-                    if (!setcache.contains("Plugins." + plname.toUpperCase() + "." + location) || setcache.get("Plugins." + plname.toUpperCase() + "." + location) == null) {
-                        setcache.set("Plugins." + plname.toUpperCase() + "." + location, input);
-                        try {
-                            setcache.save(f);
-                        } catch (Exception err) {
-                        }
-                    }
-                });
-                total++;
+                final String path = "Plugins." + plname.toUpperCase() + "." + location;
+                if (!setcache.contains(path) || setcache.get(path) == null) {
+                    plugin.set(pl, playeruuid, location, input);
+                    total++;
+                }
             } catch (Exception err) {
                 return false;
             }
@@ -667,7 +683,7 @@ public class PUUIDS {
 
     // Internal counter
     private static void wasGet() {
-        plugin.getTimes++;
+        plugin.getTimes.incrementAndGet();
     }
 
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -18,6 +18,9 @@ Advanced:
   # Only mess with the following if you are sure as to what you're doing.
   Save-Rate-Ticks: 10
   Max-Processes-Per-Queue: 25
+  # How often every online player's file is checkpointed, in seconds. A normal quit always
+  # saves play time exactly; this only limits how much of a session is lost in a hard crash.
+  Player-Update-Seconds: 300
   Allow-Post-Startup-Connections: false
   Allow-Unsafe-Reloads: false
   UUID: "0"


### PR DESCRIPTION

- The periodic update refreshed Last-On on every checkpoint without banking
  anything, and the quit handler then computed the session as "now minus
  Last-On". Everything before the last checkpoint was discarded, so a six hour
  session credited a few seconds. Play time now accrues against an in-memory
  session anchor that only exists while a player is actually online, advanced
  by whole seconds so the sub-second remainder isn't dropped each checkpoint.
- stopTimer wrote Last-On before reading it back as the join time, so a server
  shutdown credited every online player exactly zero.
- The startup import of the native Minecraft statistic multiplied ticks by 50,
  producing milliseconds, and stored that in a field held in seconds - it
  overwrote files with a play time 1000x too large. Ticks are now divided by 20.
- getFormatedPlayTime divided by 100 before formatting, so what was displayed
  was 100x too small. The formatter also kept only the largest unit, reporting
  "3 days" for 3 days and 23 hours; it now keeps the two largest.
- The quit write was skipped entirely when a player had joined within the
  cooldown window, throwing away the session it was supposed to bank.
- getPlayTime now includes the live, not yet written part of a session.

Save pipeline
- An exception anywhere in the timer body left the busy flag set forever, and
  every subsequent run returned early: all saving stopped for the lifetime of
  the server. A quitting player's null address made that reachable in normal
  play. The body is now guarded, and player data is snapshotted on the event
  thread while the Player is still valid.
- The queues were an ArrayList and a Guava Multimap shared across threads.
  Both are now concurrent, and the multimap iteration could throw
  NoSuchElementException or spin when it emptied mid-drain.
- Writes are batched per player: one load and one save per file per run
  instead of a load and up to two saves per queued value.
- Saves go through a temp file and an atomic move, so a crash mid-write can no
  longer truncate a player's file.
- queueSet no longer schedules a task on the main thread just to append to a
  list, and the task id counter is atomic.

Configuration and lifecycle
- The timer was a static final field built at class load, so it always used the
  hardcoded defaults and Advanced.Save-Rate-Ticks had no effect. It is now
  started once the config has been read, and rescheduled on reload. The rate is
  also read as ticks rather than milliseconds, as its name says.
- A Max-Processes-Per-Queue of 0 reset the save rate instead of the queue limit.
- The repeating tasks were cancelled by passing a ScheduledTask hashCode to the
  Bukkit scheduler as if it were a task id, which cancelled nothing of ours and
  could cancel another plugin's task.
- The player update timer ran every 12 seconds and the stat reset every 14
  minutes, despite comments promising 10 minutes and 12 hours. The former is
  now configurable via Advanced.Player-Update-Seconds.
- The cleanup scan read the config from another thread before onEnable had
  copied defaults, so File-Cleanup and Debug were off for the whole scan.
- Cooldowns checked Settings.Cooldowns.Enabled, which does not exist, so the
  ontime cooldown never applied. They no longer use the Bukkit scheduler
  (unavailable on Folia) or clear every player's state when one player quits.

Also
- nametoUUID parsed every file in the data folder on the calling thread, which
  is the main thread for /puuids ontime and PUUIDS.getUUID. It is now backed by
  a name index with the scan as fallback.
- addToAllWithout scheduled main thread file I/O per player file, the exact
  thing this plugin exists to avoid; it goes through the async queue now.
- removeFromIntList appended instead of removing.
- getAllPlayerUUIDs/getAllPlayerNames returned null or threw on a missing data
  folder where callers iterated the result directly.
- The update checker required the local version to equal "v4.14.5" before it
  would report anything, and never set the fields backing the in-game notice.